### PR TITLE
Tweak for Low-Memory usage. Make compatible with raspberry pi.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -81,12 +81,14 @@ RUN wget $ORIENTDB_DOWNLOAD_URL \
   && rm -rf $ORIENTDB_TMP_DIR/databases/*
 
 
-FROM openjdk:12-jdk-alpine3.9
+# there is no docker container with jdk 12 for arm. Don't know why.
+FROM adoptopenjdk:14-jre-hotspot
 
 LABEL maintainer="Convergence Labs, Inc."
 
-RUN apk add --update supervisor nginx bash && \
-    rm -rf /var/cache/apk/*
+RUN apt-get update && \
+    apt-get -y install nginx supervisor && \
+    rm -rf /var/lib/apt/lists/*
 
 ##
 ## Orient DB
@@ -122,7 +124,8 @@ COPY convergence-server.conf /convergence-server/conf/convergence-server.conf
 ##
 ## Proxy
 ##
-RUN adduser -D -g 'www' www  && \
+#RUN adduser www  && \
+RUN adduser --disabled-password --gecos "" --no-create-home --disabled-login www && \
     chown -R www:www /var/lib/nginx && \
     chown -R www:www /www
 
@@ -133,6 +136,9 @@ COPY nginx.conf /etc/nginx/nginx.conf
 ## Supervisor
 ##
 COPY supservisord.conf /etc/supervisord.conf
+
+# Fixes
+RUN sed -i 's/armv6l/armv7l/g' /orientdb/bin/server.sh
 
 EXPOSE 80
 EXPOSE 25520

--- a/src/orientdb-server-config.xml
+++ b/src/orientdb-server-config.xml
@@ -144,5 +144,12 @@
         <!-- PROFILER: configures the profiler as <seconds-for-snapshot>,<archive-snapshot-size>,<summary-size> -->
         <entry name="profiler.enabled" value="false"/>
         <!-- <entry name="profiler.config" value="30,10,10" /> -->
+        <entry name="memory.chunk.size" value="10485760"/> <!-- 10 MB instead of 2GB -->
+        <entry name="memory.leftToOS" value="80%"/> <!-- 80% instead of 20% -->
+        <entry name="memory.leftToContainer" value="80%"/> <!-- 80% instead of 20% -->
+        <entry name="memory.pool.limit" value="209715200"/> <!-- 200 MB instead of 2GB -->
+        <entry name="sbtreebonsai.linkBagCache.size" value="1000"/> <!-- 1000 instead of 100000 -->
+        <entry name="sbtreebonsai.linkBagCache.evictionSize" value="100"/> <!-- 100 instead of 1000 -->
+        <entry name="ridBag.embeddedToSbtreeBonsaiThreshold" value="-1"/> <!-- always use sb tree -->
     </properties>
 </orient-server>


### PR DESCRIPTION
Hello Convergence Team

The current convergence-omnibus image is very memory hungry. It is almost impossible to run more than this application on a less powerful machine.

This PR is not intended for merging but as a proposal for an additional, less hungry docker image.
Maybe you could also add a third alternative container that can be used on a raspberry pi.

Please see the commit message for details.

Best Regards, Daniel

(See also https://github.com/Phaiax/django-convergence-ace/ )